### PR TITLE
Generate VTIMEZONEs for Link zones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,12 @@ TZID_PREFIX ?= /citadel.org/%D_1/
 # This is what libical-evolution uses.
 #TZID_PREFIX = /softwarestudio.org/Olson_%D_1/
 
+# This is used to indicate how timezone aliases (indicated by a Link line
+# in Olson files) should be generated: The default is to symbolically link
+# the Link zone file to its authorative zone. Alternatively, if set to 0,
+# a VTIMEZONE file is generated for each Link.
+CREATE_SYMLINK ?= 1
+
 
 # Set any -I include directories to find the libical header files, and the
 # libical library to link with. You only need these if you want to run the
@@ -45,7 +51,7 @@ LIBICAL_LDADD = -lical -lpthread
 GLIB_CFLAGS = `pkg-config --cflags glib-2.0`
 GLIB_LDADD = `pkg-config --libs glib-2.0`
 
-CFLAGS = -g -DOLSON_DIR=\"$(OLSON_DIR)\" -DPRODUCT_ID='"$(PRODUCT_ID)"' -DTZID_PREFIX='"$(TZID_PREFIX)"' $(GLIB_CFLAGS) $(LIBICAL_CFLAGS)
+CFLAGS = -g -DOLSON_DIR=\"$(OLSON_DIR)\" -DPRODUCT_ID='"$(PRODUCT_ID)"' -DTZID_PREFIX='"$(TZID_PREFIX)"' -DCREATE_SYMLINK=$(CREATE_SYMLINK) $(GLIB_CFLAGS) $(LIBICAL_CFLAGS)
 
 OBJECTS = vzic.o vzic-parse.o vzic-dump.o vzic-output.o
 

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,12 @@ TZID_PREFIX ?= /citadel.org/%D_1/
 # a VTIMEZONE file is generated for each Link.
 CREATE_SYMLINK ?= 1
 
+# This indicates if top-level timezone aliases (a timezone name without
+# any '/' such as "EST5EDT") should be ignored. If 0, a VTIMEZONE is
+# generated also for top-level aliases. This option only has
+# an effect if CREATE_SYMLINK is 0, and mainly is useful for backward
+# compatibility with previous vzic versions.
+IGNORE_TOP_LEVEL_LINK ?= 1
 
 # Set any -I include directories to find the libical header files, and the
 # libical library to link with. You only need these if you want to run the
@@ -51,7 +57,11 @@ LIBICAL_LDADD = -lical -lpthread
 GLIB_CFLAGS = `pkg-config --cflags glib-2.0`
 GLIB_LDADD = `pkg-config --libs glib-2.0`
 
-CFLAGS = -g -DOLSON_DIR=\"$(OLSON_DIR)\" -DPRODUCT_ID='"$(PRODUCT_ID)"' -DTZID_PREFIX='"$(TZID_PREFIX)"' -DCREATE_SYMLINK=$(CREATE_SYMLINK) $(GLIB_CFLAGS) $(LIBICAL_CFLAGS)
+CFLAGS = -g -DOLSON_DIR=\"$(OLSON_DIR)\" -DPRODUCT_ID='"$(PRODUCT_ID)"'
+CFLAGS += -DTZID_PREFIX='"$(TZID_PREFIX)"'
+CFLAGS += -DCREATE_SYMLINK=$(CREATE_SYMLINK)
+CFLAGS += -DIGNORE_TOP_LEVEL_LINK=$(IGNORE_TOP_LEVEL_LINK)
+CFLAGS += $(GLIB_CFLAGS) $(LIBICAL_CFLAGS)
 
 OBJECTS = vzic.o vzic-parse.o vzic-dump.o vzic-output.o
 

--- a/vzic-output.c
+++ b/vzic-output.c
@@ -1746,7 +1746,7 @@ calculate_actual_time		(VzicTime	*vzictime,
     }
 
     g_date_clear (&date, 1);
-    days_in_month = g_date_days_in_month (vzictime->month + 1, vzictime->year);
+    days_in_month = g_date_get_days_in_month (vzictime->month + 1, vzictime->year);
 
   /* Note that the day_code refers to the date before we convert it to
      a wall-clock date and time. So we find the day it was referring to,
@@ -1755,7 +1755,7 @@ calculate_actual_time		(VzicTime	*vzictime,
       /* Find out what day the last day of the month is. */
       g_date_set_dmy (&date, days_in_month, vzictime->month + 1,
 		      vzictime->year);
-      weekday = g_date_weekday (&date) % 7;
+      weekday = g_date_get_weekday (&date) % 7;
 
       /* Calculate how many days we have to go back to get to day_weekday. */
       offset = (weekday + 7 - vzictime->day_weekday) % 7;
@@ -1765,7 +1765,7 @@ calculate_actual_time		(VzicTime	*vzictime,
       /* Find out what day day_number actually is. */
       g_date_set_dmy (&date, vzictime->day_number, vzictime->month + 1,
 		      vzictime->year);
-      weekday = g_date_weekday (&date) % 7;
+      weekday = g_date_get_weekday (&date) % 7;
 
       if (vzictime->day_code == DAY_WEEKDAY_ON_OR_AFTER)
 	offset = (vzictime->day_weekday + 7 - weekday) % 7;
@@ -1784,7 +1784,7 @@ calculate_actual_time		(VzicTime	*vzictime,
 
     if (vzictime->day_number <= 0) {
       vzictime->month--;
-      days_in_month = g_date_days_in_month (vzictime->month + 1, vzictime->year);
+      days_in_month = g_date_get_days_in_month (vzictime->month + 1, vzictime->year);
       vzictime->day_number += days_in_month;
     }
   }
@@ -1930,12 +1930,12 @@ fix_time_overflow			(int		*year,
 	*month = 11;
 	*year = *year - 1;
       }
-      *day = g_date_days_in_month (*month + 1, *year);
+      *day = g_date_get_days_in_month (*month + 1, *year);
     }
   } else if (day_offset == 1) {
     *day = *day + 1;
 
-    if (*day > g_date_days_in_month (*month + 1, *year)) {
+    if (*day > g_date_get_days_in_month (*month + 1, *year)) {
       *month = *month + 1;
       if (*month == 12) {
 	*month = 0;

--- a/vzic-output.c
+++ b/vzic-output.c
@@ -300,11 +300,15 @@ output_vtimezone_files		(char		*directory,
     while (links) {
       link_to = links->data;
 
+#if IGNORE_TOP_LEVEL_LINK
       /* We ignore Links that don't have a '/' in them (things like 'EST5EDT').
        */
       if (strchr (link_to, '/')) {
+#endif
         output_zone (directory, zone, link_to, zone->zone_name, rule_data);
+#if IGNORE_TOP_LEVEL_LINK
       }
+#endif
 
       links = links->next;
     }

--- a/vzic-parse.c
+++ b/vzic-parse.c
@@ -42,8 +42,6 @@
 /* The maximum number of fields on a line. */
 #define MAX_FIELDS	12
 
-#define CREATE_SYMLINK	1
-
 typedef enum
 {
   ZONE_ID		= 0,	/* The 'Zone' at the start of the line. */
@@ -498,46 +496,44 @@ parse_link_line			(ParsingData	*data)
 #endif
 
 #if CREATE_SYMLINK
-  {
-      int len = strnlen(to,254);
-      int dirs = 0;
-      int i;
-      for (i = 0; i < len; i++) {
-	  dirs += to[i] == '/' ? 1 : 0;
-      }
-      if (dirs >= 0) {
-	  char rel_from[255];
-	  char to_dir[255];
-	  char to_path[255];
-	  if (dirs == 0) {
-	      sprintf(rel_from, "%s.ics", from);
-	  } else if (dirs == 1) {
-	      sprintf(rel_from, "../%s.ics", from);
-	  } else if (dirs == 2) {
-	      sprintf(rel_from, "../../%s.ics", from);
-	  } else {
-	      return;
-	  }
-	  sprintf(to_path, "%s/%s.ics", VzicOutputDir, to);
-	  strncpy(to_dir, to_path, 254);
-	  ensure_directory_exists(dirname(to_dir));
-	  //printf("Creating symlink from %s to %s\n", rel_from, to_path);
-	  symlink(rel_from, to_path);
-      }
+  int len = strnlen(to,254);
+  int dirs = 0;
+  int i;
+  for (i = 0; i < len; i++) {
+    dirs += to[i] == '/' ? 1 : 0;
+  }
+  if (dirs >= 0) {
+    char rel_from[255];
+    char to_dir[255];
+    char to_path[255];
+    if (dirs == 0) {
+      sprintf(rel_from, "%s.ics", from);
+    } else if (dirs == 1) {
+      sprintf(rel_from, "../%s.ics", from);
+    } else if (dirs == 2) {
+      sprintf(rel_from, "../../%s.ics", from);
+    } else {
+      return;
+    }
+    sprintf(to_path, "%s/%s.ics", VzicOutputDir, to);
+    strncpy(to_dir, to_path, 254);
+    ensure_directory_exists(dirname(to_dir));
+    //printf("Creating symlink from %s to %s\n", rel_from, to_path);
+    symlink(rel_from, to_path);
   }
 #else
-  if (g_hash_table_lookup_extended (data->link_data, from,
-				    (gpointer) &old_from,
-				    (gpointer) &zone_list)) {
-    from = old_from;
-  } else {
-    from = g_strdup (from);
-    zone_list = NULL;
-  }
+    if (g_hash_table_lookup_extended (data->link_data, from,
+          (gpointer) &old_from,
+          (gpointer) &zone_list)) {
+      from = old_from;
+    } else {
+      from = g_strdup (from);
+      zone_list = NULL;
+    }
 
-  zone_list = g_list_prepend (zone_list, g_strdup (to));
+    zone_list = g_list_prepend (zone_list, g_strdup (to));
 
-  g_hash_table_insert (data->link_data, from, zone_list);
+    g_hash_table_insert (data->link_data, from, zone_list);
 #endif
 }
 

--- a/vzic-parse.c
+++ b/vzic-parse.c
@@ -156,18 +156,14 @@ static void	parse_coord			(char		*coord,
 
 void
 parse_olson_file		(char		*filename,
-				 GArray	       **zone_data,
-				 GHashTable    **rule_data,
-				 GHashTable    **link_data,
+				 GArray	       *zone_data,
+				 GHashTable    *rule_data,
+				 GHashTable    *link_data,
 				 int		*max_until_year)
 {
   ParsingData data;
   FILE *fp;
   int zone_continues = 0;
-
-  *zone_data = g_array_new (FALSE, FALSE, sizeof (ZoneData));
-  *rule_data = g_hash_table_new (g_str_hash, g_str_equal);
-  *link_data = g_hash_table_new (g_str_hash, g_str_equal);
 
   fp = fopen (filename, "r");
   if (!fp) {
@@ -176,9 +172,9 @@ parse_olson_file		(char		*filename,
   }
 
   data.filename = filename;
-  data.zone_data = *zone_data;
-  data.rule_data = *rule_data;
-  data.link_data = *link_data;
+  data.zone_data = zone_data;
+  data.rule_data = rule_data;
+  data.link_data = link_data;
   data.max_until_year = 0;
 
   for (data.line_number = 0; ; data.line_number++) {

--- a/vzic-parse.c
+++ b/vzic-parse.c
@@ -633,12 +633,12 @@ parse_day			(ParsingData	*data,
   char *day_part, *p;
   DayCode day_code;
 
+  *day = *weekday = 0;
+
   if (!field) {
     *day = 1;
     return DAY_SIMPLE;
   }
-
-  *day = *weekday = 0;
 
   if (!strncmp (field, "last", 4)) {
     *weekday = parse_weekday (data, field + 4);

--- a/vzic-parse.h
+++ b/vzic-parse.h
@@ -28,9 +28,9 @@
 #include <glib.h>
 
 void		parse_olson_file		(char		*filename,
-						 GArray	       **zone_data,
-						 GHashTable    **rule_data,
-						 GHashTable    **link_data,
+						 GArray	       *zone_data,
+						 GHashTable    *rule_data,
+						 GHashTable    *link_data,
 						 int		*max_until_year);
 
 GHashTable*	parse_zone_tab			(char		*filename);

--- a/vzic.c
+++ b/vzic.c
@@ -265,7 +265,7 @@ convert_olson_files		(GPtrArray *olson_filenames)
 static void
 usage				(void)
 {
-  fprintf (stderr, "Usage: vzic [--dump] [--dump-changes] [--no-rrules] [--no-rdates] [--pure] [--output-dir <directory>] [--url-prefix <url>] [--olson-dir <directory>]\n");
+  fprintf (stderr, "Usage: vzic [--dump] [--dump-changes] [--no-rrules] [--no-rdates] [--pure] [--gen-links] [--output-dir <directory>] [--url-prefix <url>] [--olson-dir <directory>]\n");
 
   exit (1);
 }

--- a/vzic.h
+++ b/vzic.h
@@ -60,6 +60,12 @@ extern GList*	VzicTimeZoneNames;
 #define CREATE_SYMLINK 1
 #endif
 
+/* Defines if timezone aliases at top-level ("e.g. EST5EDT")
+ * should be ignored. */
+#ifndef IGNORE_TOP_LEVEL_LINK
+#define IGNORE_TOP_LEVEL_LINK 1
+#endif
+
 /* Days can be expressed either as a simple month day number, 1-31, or a rule
    such as the last Sunday, or the first Monday on or after the 8th. */
 typedef enum

--- a/vzic.h
+++ b/vzic.h
@@ -55,6 +55,11 @@ extern GList*	VzicTimeZoneNames;
 /* The maximum size of any complete pathname. */
 #define PATHNAME_BUFFER_SIZE	1024
 
+/* Defines if to generate symbolic links or VTIMEZONEs for zone aliases */
+#ifndef CREATE_SYMLINK
+#define CREATE_SYMLINK 1
+#endif
+
 /* Days can be expressed either as a simple month day number, 1-31, or a rule
    such as the last Sunday, or the first Monday on or after the 8th. */
 typedef enum


### PR DESCRIPTION
As discussed with @ksmurchison, this adds the --gen-links option to vzic which instructs vzic to generate a VTIMEZONE file for each zone alias defined in a tzdata Link line. The generated VTIMEZONE has the TZID of the link zone and set its TZID-ALIAS-OF property to the authoritative zone for that link.
In addition it aligns the result of symbolic link generation with the result of the new VTIMEZONE output. Before, symbolic links were generated for any Link zone, but VTIMEZONEs of Links only were generated if the zone name was not a to-level zone.