### PR TITLE
Build vzic and zoneinfo via GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build and run on GitHub Actions
+
+on:
+  push:
+    branches: [ "main", "build_automation" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Build Docker Image
+      run: docker build -t vzic_build .
+
+    - name: Create container
+      run: docker create --name vzic -w /tmp vzic_build './build.sh'
+
+    - name: Copy code to container
+      run: docker cp . vzic:/tmp/
+
+    - name: Run Build
+      run: docker start -a vzic
+
+    - name: Copy artifacts from container
+      run: docker cp vzic:/tmp/build/out .
+
+    - name: Get VZIC environment variables into GitHub Actions
+      run: |
+        . ./settings.config
+        echo "VZIC_RELEASE_NAME=$VZIC_RELEASE_NAME" >> $GITHUB_ENV
+
+    - name: Archive artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: zoneinfo
+        path: out/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test-vzic
 vzic
 *.o
 *~
+/build

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+
+# This script does
+#
+# * download the specified tzdata archive
+# * download the specified master zoneinfo archive
+# * build vzic
+# * run vzic on the downloaded tzdata
+# * merge the new zoneinfo into the master zoneinfo
+# * archive the result and copy it to the specified output dir
+# 
+# The URLS for the master zoneinfo and new tzdata are read from settings.config file.
+#
+
+set -e
+
+# read settings file
+. ./settings.config
+
+#clean build dir
+if [ -d build ]; then rm -r build; fi
+mkdir -p build
+
+echo "Building $VZIC_RELEASE_NAME"
+
+if [[ ${VZIC_TZDATA_ARCHIVE_URL} ]]; then
+    echo "Downloading tzdata from $VZIC_TZDATA_ARCHIVE_URL"
+    wget -q -O build/tzdata.tar.gz $VZIC_TZDATA_ARCHIVE_URL
+    export VZIC_TZDATA_ARCHIVE_PATH=build/tzdata.tar.gz
+fi
+
+echo "Extracting new tzdata"
+mkdir -p build/tzdata
+tar -xzf $VZIC_TZDATA_ARCHIVE_PATH -C build/tzdata
+
+echo "Building vzic"
+make -B OLSON_DIR=tzdata PRODUCT_ID="$VZIC_PRODID" TZID_PREFIX="$VZIC_TZID_PREFIX"
+
+echo "Running vzic"
+./vzic --olson-dir build/tzdata --output-dir build/zoneinfo --pure
+
+if [[ ${VZIC_MASTER_ZONEINFO_ARCHIVE_URL} ]]; then
+    echo "Downloading master zoneinfo from $VZIC_MASTER_ZONEINFO_ARCHIVE_URL"
+    wget -q -O build/zoneinfo_master.tar.gz $VZIC_MASTER_ZONEINFO_ARCHIVE_URL
+
+    export VZIC_MASTER_ZONEINFO_ARCHIVE_PATH=build/zoneinfo_master.tar.gz
+fi
+
+if [[ ${VZIC_MASTER_ZONEINFO_ARCHIVE_PATH} ]]; then
+    echo "Extracting master zoneinfo $VZIC_MASTER_ZONEINFO_ARCHIVE_PATH"
+    mkdir -p build/zoneinfo_master
+    tar -xzf $VZIC_MASTER_ZONEINFO_ARCHIVE_PATH -C build/zoneinfo_master
+
+    # define variables used in vzic-merge.pl
+    export VZIC_ZONEINFO_MASTER=`pwd`/build/zoneinfo_master
+    export VZIC_ZONEINFO_NEW=`pwd`/build/zoneinfo
+
+    echo "Merging"
+    ./vzic-merge.pl
+
+    # copy updated zones
+    cp $VZIC_ZONEINFO_NEW/zones.* $VZIC_ZONEINFO_MASTER 
+else
+    echo "No master zoneinfo configured. The new zoneinfo will not be merged and kept as is."
+    export VZIC_ZONEINFO_MASTER=`pwd`/build/zoneinfo
+fi
+
+echo "Creating output archive"
+mkdir -p build/out
+cd $VZIC_ZONEINFO_MASTER
+tar -czf "../out/zoneinfo_$VZIC_RELEASE_NAME.tar.gz" * 
+cd ../..

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,17 @@
+# escape=`
+
+FROM ubuntu
+
+RUN apt-get update
+
+# build tools
+RUN apt-get -y install make
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install pkg-config
+RUN apt-get -y install build-essential
+RUN apt-get -y install libglib2.0-dev
+
+# wget used to download tzdata and previous zoneinfo
+RUN apt-get -y install wget
+
+# perl used to merge new zoneinfo with previous version
+RUN apt-get -y install perl

--- a/settings.config
+++ b/settings.config
@@ -1,0 +1,17 @@
+
+VZIC_RELEASE_NAME=2019a
+VZIC_BASE_RELEASE_NAME=
+
+# The source tzdata is downloaded from this URL.
+VZIC_TZDATA_ARCHIVE_URL="https://data.iana.org/time-zones/releases/tzdata$VZIC_RELEASE_NAME.tar.gz"
+
+# If VZIC_MASTER_ZONEINFO_ARCHIVE_URL is set, the script tries to download a an output from a previous
+# version and merge the new output with the previous one using vzic-merge.pl.
+# VZIC_MASTER_ZONEINFO_ARCHIVE_PATH can point to a local file and be used instead of VZIC_MASTER_ZONEINFO_ARCHIVE_URL.
+# If neither of them is set, then the newly generated zoneinfo is kept as is.
+
+# VZIC_MASTER_ZONEINFO_ARCHIVE_URL=""
+# VZIC_MASTER_ZONEINFO_ARCHIVE_PATH=""
+
+VZIC_PRODID="-//github.com/libical/vzic//NONSGML ICS//EN"
+VZIC_TZID_PREFIX="/github.com/libical/%D_1/"

--- a/vzic-merge.pl
+++ b/vzic-merge.pl
@@ -33,8 +33,8 @@ use Getopt::Long;
 #
 
 # Set these to the toplevel directories of the 2 sets of VTIMEZONE files.
-$MASTER_ZONEINFO_DIR = "/home/allen/projects/libical/libical/zoneinfo";
-$NEW_ZONEINFO_DIR = "/home/allen/projects/libical/vzic/zoneinfo";
+$MASTER_ZONEINFO_DIR = $ENV{'VZIC_ZONEINFO_MASTER'};
+$NEW_ZONEINFO_DIR = $ENV{'VZIC_ZONEINFO_NEW'};
 
 # Set this to 1 if you have version numbers in the TZID like libical.
 $LIBICAL_VERSIONING = 1;

--- a/vzic-merge.pl
+++ b/vzic-merge.pl
@@ -86,10 +86,14 @@ foreach $new_file (`find -name "*.ics"`) {
 	$new_contents_copy = $new_contents;
 
 	# Strip the TZID from both contents.
-	$new_contents_copy =~ s/^TZID:\S+$//m;
+	$new_contents_copy =~ s/^TZID:[\S\r]+$//m;
 	$new_tzid = $&;
-	$master_contents =~ s/^TZID:\S+$//m;
+	$master_contents =~ s/^TZID:[\S\r]+$//m;
 	$master_tzid = $&;
+
+	# Strip LAST-MODIFIED
+	$new_contents_copy =~ s/^LAST-MODIFIED:[\S\r]+$//m;
+	$master_contents =~ s/^LAST-MODIFIED:[\S\r]+$//m;
 
 #	print "Matched: $master_tzid\n";
 


### PR DESCRIPTION
Introduce a build based on Docker and GitHub Action that generates incremental zoneinfo as discussed in #4. I.e. it
* buld vzic
* downloads tzdata as configured in `settings.config`
* downloads a previous version of generated zoneinfo.
* runs vzic on the new tzdata
* merges the generated tzdata into the previous version
* uploads the generated zoneinfo as a build artifact

There are a few things that should be discussed, inlcuding:
* The PRODID and TZID-prefix have been configured to `-//github.com/libical/vzic//NONSGML ICS//EN` and `/github.com/libical/%D_1/`. This is not in line with the default configured in the makefile but seems to be more appropriate. Not sure, whether there's a good reason for keeping the defaults?
* Move the releases of the generated zoneinfo to a dedicated repo instead of cluttering this one?

