### PR TITLE
Remove warning 'Zone description not found'.

### DIFF
--- a/vzic-dump.c
+++ b/vzic-dump.c
@@ -382,7 +382,6 @@ dump_time_zone_names		(GList		*names,
 	       zone_desc->longitude[2],
 	       zone_name);
     } else {
-      g_print ("Zone description not found for: %s\n", zone_name);
       fprintf (fp, "%s\n", zone_name);
     }
 


### PR DESCRIPTION
Remove the warning 'Zone description not found' as it doesn't seem to indicate a real problem and is somewhat irritating. See #9.